### PR TITLE
Drop FGS specialUse type for Play resubmission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,6 @@
 
     <!-- Foreground service types permissions (for targeting devices running on android 14 and above) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
@@ -128,10 +127,7 @@
         <service
             android:name=".RadarServiceImpl"
             android:exported="false"
-            android:foregroundServiceType="specialUse|health|location|microphone|connectedDevice" >
-            <property
-                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="@string/fgs_special_type_use"/>
+            android:foregroundServiceType="health|location|microphone|connectedDevice" >
         </service>
 
         <service android:name=".AuthServiceImpl" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,7 +139,6 @@
     <string name="crash_restart_title">Please start RADAR pRMT</string>
     <string name="crash_restart_text">RADAR pRMT has been crashed. Please press this notification to start it again</string>
 
-    <string name="fgs_special_type_use">RADAR pRMT keeps a long-running foreground service active so it can continuously collect and upload health, sensor, and location data from the participant\'s phone and any paired study devices (e.g. Bluetooth wearables) to the research study server. The service must keep running while the phone is locked or the app is in the background, because participants contribute data 24/7 for the duration of the study.</string>
     <string name="no_plugins_activated">No plugins activated</string>
 
     <string name="bg_location_disclosure_title">RADAR pRMT needs background location access</string>

--- a/app/src/selfRelease/AndroidManifest.xml
+++ b/app/src/selfRelease/AndroidManifest.xml
@@ -24,7 +24,6 @@
 
     <!-- Foreground service types permissions (for targeting devices running on android 14 and above) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
@@ -131,10 +130,7 @@
         <service
             android:name=".RadarServiceImpl"
             android:exported="false"
-            android:foregroundServiceType="specialUse|health|location|microphone|connectedDevice" >
-            <property
-                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="@string/fgs_special_type_use"/>
+            android:foregroundServiceType="health|location|microphone|connectedDevice" >
         </service>
 
         <service android:name=".AuthServiceImpl" />


### PR DESCRIPTION
The app declared the `RadarService` with specialUse (alongside health, location, microphone, connectedDevice). Google Play rejected this.
I think dropping the specialUse permission should work, as RadarService is now initially started as a bound service and later promoted to foreground service, so at the beginning we can start the service without any foreground service type which previously we were filling with the specialUse permission, which now can be removed because this service behavior change. 