### PR TITLE
Start data collection from an explicit onboarding step

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,9 +20,7 @@
 
     <!-- Foreground service types permissions (for targeting devices running on android 14 and above) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
 
     <supports-screens android:largeScreens="true"
         android:xlargeScreens="true" />
@@ -127,7 +125,7 @@
         <service
             android:name=".RadarServiceImpl"
             android:exported="false"
-            android:foregroundServiceType="health|location|microphone|connectedDevice" >
+            android:foregroundServiceType="location|connectedDevice" >
         </service>
 
         <service android:name=".AuthServiceImpl" />

--- a/app/src/main/java/org/radarcns/detail/LoginActivityImpl.kt
+++ b/app/src/main/java/org/radarcns/detail/LoginActivityImpl.kt
@@ -39,6 +39,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import org.radarbase.android.RadarApplication.Companion.radarConfig
 import org.radarbase.android.RadarConfiguration.Companion.BASE_URL_KEY
+import org.radarbase.android.RadarConfiguration.Companion.ENABLE_DATA_COLLECTION_DISCLOSURE
 import org.radarbase.android.auth.*
 import org.radarbase.android.auth.AuthService.Companion.BASE_URL_PROPERTY
 import org.radarbase.android.auth.oauth2.OAuth2LoginManager
@@ -376,13 +377,18 @@ class LoginActivityImpl :
             logger.debug("Enabling Firebase Analytics")
             FirebaseAnalytics.getInstance(this@LoginActivityImpl).setAnalyticsCollectionEnabled(true)
         }
-        mainHandler.post { startDataCollectionFragment() }
+        if (radarConfig.latestConfig.getBoolean(ENABLE_DATA_COLLECTION_DISCLOSURE, false)) {
+            mainHandler.post { startDataCollectionFragment() }
+        } else {
+            onStartDataCollection()
+        }
     }
 
     override fun onStartDataCollection() {
         logger.info("Participant started data collection. Opening main activity.")
         authConnection.applyBinder {
             applyState {
+                logger.info("Updating privacyPolicyAccepted {}", this)
                 super.loginSucceeded(null, this)
             }
         }

--- a/app/src/main/java/org/radarcns/detail/LoginActivityImpl.kt
+++ b/app/src/main/java/org/radarcns/detail/LoginActivityImpl.kt
@@ -62,6 +62,7 @@ class LoginActivityImpl :
     LoginActivity(),
     NetworkConnectedReceiver.NetworkConnectedListener,
     PrivacyPolicyFragment.OnFragmentInteractionListener,
+    StartDataCollectionFragment.OnStartDataCollectionListener,
     StudyIdFragment.FragmentInteractionListener {
     private var startActivityFuture: Runnable? = null
     private var didModifyBaseUrl: Boolean = false
@@ -374,10 +375,25 @@ class LoginActivityImpl :
             }
             logger.debug("Enabling Firebase Analytics")
             FirebaseAnalytics.getInstance(this@LoginActivityImpl).setAnalyticsCollectionEnabled(true)
+        }
+        mainHandler.post { startDataCollectionFragment() }
+    }
+
+    override fun onStartDataCollection() {
+        logger.info("Participant started data collection. Opening main activity.")
+        authConnection.applyBinder {
             applyState {
-                logger.info("Updating privacyPolicyAccepted {}", this)
                 super.loginSucceeded(null, this)
             }
+        }
+    }
+
+    private fun startDataCollectionFragment() {
+        logger.info("Starting data collection fragment")
+        try {
+            createFragmentLayout(R.id.start_data_collection_fragment, StartDataCollectionFragment())
+        } catch (ex: IllegalStateException) {
+            logger.error("Failed to start data collection fragment: is login activity already closed?", ex)
         }
     }
 

--- a/app/src/main/java/org/radarcns/detail/SourceRowView.kt
+++ b/app/src/main/java/org/radarcns/detail/SourceRowView.kt
@@ -191,7 +191,7 @@ class SourceRowView internal constructor(
     private val infoEnabled: Boolean
         get() = mainActivity.radarConfig.latestConfig.getBoolean(
             RadarConfiguration.ENABLE_SOURCE_INFO_UI,
-            true)
+            false)
 
     private fun updateInfoButton() {
         mInfoButton.visibility = if (infoEnabled) View.VISIBLE else View.GONE

--- a/app/src/main/java/org/radarcns/detail/SourceRowView.kt
+++ b/app/src/main/java/org/radarcns/detail/SourceRowView.kt
@@ -24,7 +24,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
+import androidx.core.text.HtmlCompat
 import org.radarbase.android.MainActivity
+import org.radarbase.android.RadarApplication.Companion.radarConfig
+import org.radarbase.android.RadarConfiguration
 import org.radarbase.android.source.BaseSourceState
 import org.radarbase.android.source.SourceProvider
 import org.radarbase.android.source.SourceServiceConnection
@@ -45,6 +48,7 @@ class SourceRowView internal constructor(
     private val mStatusIcon: ImageView
     private val mBatteryLabel: ImageView
     private val mSourceNameLabel: TextView
+    private val mInfoButton: View
     private val devicePreferences: SharedPreferences =
         mainActivity.getSharedPreferences("device." + connection.serviceClassName, Context.MODE_PRIVATE)
     private val filter = ChangeRunner("")
@@ -73,6 +77,8 @@ class SourceRowView internal constructor(
             }
             findViewById<View>(R.id.refreshButton)
                     .setOnClickListener { reconnectSource() }
+            mInfoButton = findViewById(R.id.infoButton)
+            mInfoButton.setOnClickListener { showSourceInfo() }
         }
         setFilter(devicePreferences.getString("filter", "") ?: "")
     }
@@ -144,6 +150,7 @@ class SourceRowView internal constructor(
         updateBattery()
         updateSourceName()
         updateSourceStatus()
+        updateInfoButton()
     }
 
     private fun updateSourceStatus() {
@@ -179,6 +186,39 @@ class SourceRowView internal constructor(
         sourceNameCache.applyIfChanged(sourceName ?: "\u2014") {
             mSourceNameLabel.text = it
         }
+    }
+
+    private val infoEnabled: Boolean
+        get() = mainActivity.radarConfig.latestConfig.getBoolean(
+            RadarConfiguration.ENABLE_SOURCE_INFO_UI,
+            true)
+
+    private fun updateInfoButton() {
+        mInfoButton.visibility = if (infoEnabled) View.VISIBLE else View.GONE
+    }
+
+    /**
+     * Show the data types collected for this row. For a grouped row such as the phone, every plugin
+     * sharing the same [SourceProvider.infoGroup] is listed, each with its own name and description.
+     */
+    private fun showSourceInfo() {
+        val group = provider.infoGroup
+        val members = if (group != null) {
+            (mainActivity.radarService?.connections ?: emptyList())
+                .filter { it.infoGroup == group }
+        } else {
+            emptyList()
+        }.ifEmpty { listOf(provider) }
+
+        val body = members.joinToString("<br/><br/>") { p ->
+            "<b>${p.displayName}</b><br/>${p.description.orEmpty()}"
+        }
+
+        AlertDialog.Builder(mainActivity)
+            .setTitle(provider.displayName)
+            .setMessage(HtmlCompat.fromHtml(body, HtmlCompat.FROM_HTML_MODE_LEGACY))
+            .setPositiveButton(R.string.ok, null)
+            .show()
     }
 
     companion object {

--- a/app/src/main/java/org/radarcns/detail/StartDataCollectionFragment.kt
+++ b/app/src/main/java/org/radarcns/detail/StartDataCollectionFragment.kt
@@ -6,6 +6,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import org.radarbase.android.RadarApplication.Companion.radarConfig
+import org.radarbase.android.RadarConfiguration.Companion.DATA_COLLECTION_DISCLOSURE_BODY_KEY
+import org.radarbase.android.RadarConfiguration.Companion.DATA_COLLECTION_DISCLOSURE_TITLE_KEY
 import org.radarcns.detail.databinding.FragmentStartDataCollectionBinding
 import org.slf4j.LoggerFactory
 
@@ -28,9 +31,18 @@ class StartDataCollectionFragment : Fragment() {
         .root
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        binding?.startDataCollectionButton?.setOnClickListener {
-            logger.info("Participant tapped start data collection")
-            listener?.onStartDataCollection()
+        val config = requireContext().radarConfig.latestConfig
+        binding?.apply {
+            dataCollectionTitle.text = config.optString(DATA_COLLECTION_DISCLOSURE_TITLE_KEY)
+                ?.takeIf { it.isNotBlank() }
+                ?: getString(R.string.data_collection_title)
+            dataCollectionBody.text = config.optString(DATA_COLLECTION_DISCLOSURE_BODY_KEY)
+                ?.takeIf { it.isNotBlank() }
+                ?: getString(R.string.data_collection_disclosure)
+            startDataCollectionButton.setOnClickListener {
+                logger.info("Participant tapped start data collection")
+                listener?.onStartDataCollection()
+            }
         }
     }
 

--- a/app/src/main/java/org/radarcns/detail/StartDataCollectionFragment.kt
+++ b/app/src/main/java/org/radarcns/detail/StartDataCollectionFragment.kt
@@ -1,0 +1,64 @@
+package org.radarcns.detail
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import org.radarcns.detail.databinding.FragmentStartDataCollectionBinding
+import org.slf4j.LoggerFactory
+
+/**
+ * Shown once during onboarding, right after the privacy policy is accepted. Data collection only
+ * begins when the participant taps start here, which lets the main screen open. Nothing is persisted
+ * by this fragment, so already onboarded participants who go straight to the main screen never see
+ * it again.
+ */
+class StartDataCollectionFragment : Fragment() {
+    private var listener: OnStartDataCollectionListener? = null
+    private var binding: FragmentStartDataCollectionBinding? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = FragmentStartDataCollectionBinding.inflate(inflater, container, false)
+        .also { binding = it }
+        .root
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        binding?.startDataCollectionButton?.setOnClickListener {
+            logger.info("Participant tapped start data collection")
+            listener?.onStartDataCollection()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        listener = context as? OnStartDataCollectionListener
+            ?: throw RuntimeException("$context must implement OnStartDataCollectionListener")
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        listener = null
+    }
+
+    /**
+     * Implemented by the hosting activity so the start action can move the onboarding flow on to the
+     * main screen.
+     */
+    interface OnStartDataCollectionListener {
+        fun onStartDataCollection()
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(StartDataCollectionFragment::class.java)
+    }
+}

--- a/app/src/main/res/drawable/baseline_info_24.xml
+++ b/app/src/main/res/drawable/baseline_info_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M11,7h2v2h-2zM11,11h2v6h-2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z" />
+</vector>

--- a/app/src/main/res/layout/activity_overview_source_row.xml
+++ b/app/src/main/res/layout/activity_overview_source_row.xml
@@ -34,6 +34,21 @@
         android:maxLines="1"/>
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/infoButton"
+        style="?attr/borderlessButtonStyle"
+        android:layout_width="52dp"
+        android:layout_height="52dp"
+        android:insetLeft="0dp"
+        android:insetTop="0dp"
+        android:insetRight="0dp"
+        android:insetBottom="0dp"
+        android:visibility="gone"
+        app:icon="@drawable/baseline_info_24"
+        android:contentDescription="@string/source_info"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp" />
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/filterSourceButton"
         android:layout_width="52dp"
         android:layout_height="52dp"

--- a/app/src/main/res/layout/fragment_start_data_collection.xml
+++ b/app/src/main/res/layout/fragment_start_data_collection.xml
@@ -34,6 +34,7 @@
                     app:srcCompat="@drawable/vd_logo" />
 
                 <TextView
+                    android:id="@+id/dataCollectionTitle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/size_medium"
@@ -42,6 +43,7 @@
                     style="@style/TextAppearance.MaterialComponents.Headline6" />
 
                 <TextView
+                    android:id="@+id/dataCollectionBody"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/size_medium"

--- a/app/src/main/res/layout/fragment_start_data_collection.xml
+++ b/app/src/main/res/layout/fragment_start_data_collection.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:padding="@dimen/size_medium"
+    tools:context=".StartDataCollectionFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:cardCornerRadius="@dimen/size_medium"
+            app:cardElevation="@dimen/size_small">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:orientation="vertical"
+                android:padding="@dimen/size_large">
+
+                <ImageView
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:contentDescription="@string/app_name"
+                    app:srcCompat="@drawable/vd_logo" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/size_medium"
+                    android:gravity="center"
+                    android:text="@string/data_collection_title"
+                    style="@style/TextAppearance.MaterialComponents.Headline6" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/size_medium"
+                    android:gravity="center"
+                    android:text="@string/data_collection_disclosure"
+                    style="@style/TextAppearance.MaterialComponents.Body2" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/startDataCollectionButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/size_large"
+                    android:text="@string/start_data_collection" />
+
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,4 +1,5 @@
 <resources>
     <item name="privacy_policy_fragment" type="id"/>
     <item name="study_id_fragment" type="id"/>
+    <item name="start_data_collection_fragment" type="id"/>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,4 +169,9 @@
     <string name="consent">Consent</string>
     <string name="filter_split_regex">,</string>
     <string name="special_fgs_explanation">RadarService operates with plugins and modules that may need permissions beyond standard foreground service types. Defining a special use subtype ensures compliance with Android’s requirements for permissions that may vary dynamically based on active plugins</string>
+
+    <string name="start_data_collection">Start data collection</string>
+    <string name="source_info">Information</string>
+    <string name="data_collection_title">Start data collection</string>
+    <string name="data_collection_disclosure">RADAR pRMT collects research data for the study you just consented to. This includes your phone sensors and location, and a wearable device if you set one up.\n\nData collection runs in the background so the study keeps receiving your data. Tap the button below to start.</string>
 </resources>

--- a/app/src/playStore/java/org/radarcns/detail/RadarServiceImpl.kt
+++ b/app/src/playStore/java/org/radarcns/detail/RadarServiceImpl.kt
@@ -24,34 +24,28 @@ import org.radarbase.android.RadarService
 import org.radarbase.android.config.SingleRadarConfiguration
 import org.radarbase.android.source.SourceProvider
 import org.radarbase.monitor.application.ApplicationStatusProvider
-import org.radarbase.passive.audio.OpenSmileAudioProvider
 import org.radarbase.passive.bittium.FarosProvider
-import org.radarbase.passive.google.activity.GoogleActivityProvider
 import org.radarbase.passive.google.places.GooglePlacesProvider
-import org.radarbase.passive.google.sleep.GoogleSleepProvider
 import org.radarbase.passive.phone.PhoneBluetoothProvider
 import org.radarbase.passive.phone.PhoneContactListProvider
 import org.radarbase.passive.phone.PhoneLocationProvider
 import org.radarbase.passive.phone.PhoneSensorProvider
 import org.radarbase.passive.phone.audio.input.PhoneAudioInputProvider
-//import org.radarbase.passive.polar.PolarProvider
 import org.radarbase.passive.phone.usage.PhoneUsageProvider
+import org.radarbase.passive.polar.PolarProvider
 import org.radarbase.passive.weather.WeatherApiProvider
 
 class RadarServiceImpl : RadarService() {
     override val plugins: List<SourceProvider<*>> = listOf(
         ApplicationStatusProvider(this),
-        OpenSmileAudioProvider(this),
         FarosProvider(this),
-//        PolarProvider(this),
+        PolarProvider(this),
         PhoneBluetoothProvider(this),
         PhoneContactListProvider(this),
         PhoneLocationProvider(this),
         PhoneSensorProvider(this),
         PhoneUsageProvider(this),
         WeatherApiProvider(this),
-        GoogleActivityProvider(this),
-        GoogleSleepProvider(this),
         GooglePlacesProvider(this),
         PhoneAudioInputProvider(this)
     )

--- a/app/src/selfRelease/AndroidManifest.xml
+++ b/app/src/selfRelease/AndroidManifest.xml
@@ -24,9 +24,7 @@
 
     <!-- Foreground service types permissions (for targeting devices running on android 14 and above) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
 
     <supports-screens android:largeScreens="true"
         android:xlargeScreens="true" />
@@ -130,7 +128,7 @@
         <service
             android:name=".RadarServiceImpl"
             android:exported="false"
-            android:foregroundServiceType="health|location|microphone|connectedDevice" >
+            android:foregroundServiceType="location|connectedDevice" >
         </service>
 
         <service android:name=".AuthServiceImpl" />

--- a/app/src/selfRelease/java/org/radarcns/detail/RadarServiceImpl.kt
+++ b/app/src/selfRelease/java/org/radarcns/detail/RadarServiceImpl.kt
@@ -35,9 +35,7 @@ import org.radarbase.android.util.toPendingIntentFlag
 import org.radarbase.monitor.application.ApplicationStatusProvider
 import org.radarbase.passive.audio.OpenSmileAudioProvider
 import org.radarbase.passive.bittium.FarosProvider
-import org.radarbase.passive.google.activity.GoogleActivityProvider
 import org.radarbase.passive.google.places.GooglePlacesProvider
-import org.radarbase.passive.google.sleep.GoogleSleepProvider
 import org.radarbase.passive.phone.PhoneBluetoothProvider
 import org.radarbase.passive.phone.PhoneContactListProvider
 import org.radarbase.passive.phone.PhoneLocationProvider
@@ -65,7 +63,6 @@ class RadarServiceImpl : RadarService() {
 
     override val plugins: List<SourceProvider<*>> = listOf(
         ApplicationStatusProvider(this),
-        OpenSmileAudioProvider(this),
         FarosProvider(this),
         PolarProvider(this),
         PhoneBluetoothProvider(this),
@@ -75,8 +72,6 @@ class RadarServiceImpl : RadarService() {
         PhoneLogProvider(this),
         PhoneUsageProvider(this),
         WeatherApiProvider(this),
-        GoogleActivityProvider(this),
-        GoogleSleepProvider(this),
         GooglePlacesProvider(this),
         PhoneAudioInputProvider(this)
     )


### PR DESCRIPTION
 Currently the data collection starts on its own once the main screen opened. Now a new participant sees a short screen after consent that explains what is collected and  begins only when they tap start. The Play Store build also declares just location and connected device foreground service types, and each source row gains an info button describing what it collects.

These can be enabled or disbled via firebase remote configs